### PR TITLE
Update Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - test-app/**/*
+  NewCops: enable
 
 # Public docs are sufficient (for now).
 Style/Documentation:

--- a/lib/prawn-rails-forms.rb
+++ b/lib/prawn-rails-forms.rb
@@ -15,4 +15,4 @@ module PrawnRailsForms
   end
 end
 
-PrawnRails::Document.send(:include, PrawnRailsForms::DocumentExtensions)
+PrawnRails::Document.include PrawnRailsForms::DocumentExtensions

--- a/lib/prawn-rails-forms/field_row.rb
+++ b/lib/prawn-rails-forms/field_row.rb
@@ -5,12 +5,12 @@ module PrawnRailsForms
     attr_accessor :document, :height, :units, :x, :y, :unit_width
 
     # 'x' and 'y' are easily understood in this context
-    # rubocop:disable Naming/UncommunicativeMethodParamName
+    # rubocop:disable Naming/MethodParameterName
     def initialize(document, height, units, x, y, unit_width)
       @document, @height, @units, @x, @y, @unit_width =
         document, height, units, x, y, unit_width
     end
-    # rubocop:enable Naming/UncommunicativeMethodParamName
+    # rubocop:enable Naming/MethodParameterName
 
     def at_height(height, options = {})
       @y -= height

--- a/prawn-rails-forms.gemspec
+++ b/prawn-rails-forms.gemspec
@@ -16,9 +16,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split "\x0"
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.5.0'
   spec.add_dependency 'prawn-rails', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1.2'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 0.49'
+  spec.add_development_dependency 'rubocop', '~> 1.13'
 end


### PR DESCRIPTION
And dropped support for Ruby < 2.5. This was primarily because Rubocop doesn't support it, but 2.4 was also EOL a little over a year ago.

Also made a few suggested fixes.