### PR TITLE
Add Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'


### PR DESCRIPTION
Noticed that rake was a development dependency, but there were no rake tasks. Figured we could use the Bundler gem management help.