### PR TITLE
Explicitly require the gems from the test app

### DIFF
--- a/prawn-rails-forms.gemspec
+++ b/prawn-rails-forms.gemspec
@@ -19,7 +19,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
   spec.add_dependency 'prawn-rails', '~> 1.0'
 
+  rails_version = '~> 6.0'
+  spec.add_development_dependency 'actionpack', rails_version
+  spec.add_development_dependency 'actionview', rails_version
   spec.add_development_dependency 'bundler', '~> 2.2.18'
+  spec.add_development_dependency 'railties', rails_version
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 1.13'
 end

--- a/test_app.rb
+++ b/test_app.rb
@@ -8,6 +8,7 @@ gemfile do
   rails_version = '~> 6.0'
   gem 'actionpack', rails_version
   gem 'actionview', rails_version
+  gem 'railties', rails_version
 
   gem 'prawn-rails-forms', path: './', require: false
 end


### PR DESCRIPTION
The `prawn-rails` gem doesn't explicitly require railties anymore, but we still need it in order to boot the test app.

Closes #39